### PR TITLE
fix: update TodoSequencer and its unit tests

### DIFF
--- a/ToDoIt.Tests/Data/TodoSequencerTests.cs
+++ b/ToDoIt.Tests/Data/TodoSequencerTests.cs
@@ -6,39 +6,43 @@ namespace ToDoIt.Tests.Data
     public class TodoSequencerTests
     {
         [Fact]
-        public void TodoSequencer_TestIdIncrement()
+        public void TodoIdIncrementWorks()
         {
             // Arrange
-            int firstIdRef = 1;
-            int secondIdRef = 2;
-            int thirdIdRef = 3;
+            int expectedFirstTodoId = 1;
+            int expectedSecondTodoId = 2;
+            int expectedThirdTodoId = 3;
+            int actualFirstTodoId;
+            int actualSecondTodoId;
+            int actualThirdTodoId;
 
             // Act
-            int firstTodoId = TodoSequencer.NextTodoId();
-            int secondTodoId = TodoSequencer.NextTodoId();
-            int thirdTodoId = TodoSequencer.NextTodoId();
+            TodoSequencer.reset();
+            actualFirstTodoId = TodoSequencer.nextTodoId();
+            actualSecondTodoId = TodoSequencer.nextTodoId();
+            actualThirdTodoId = TodoSequencer.nextTodoId();
 
-            // Assert        
-            Assert.Equal(firstTodoId, firstIdRef);
-            Assert.Equal(secondTodoId, secondIdRef);
-            Assert.Equal(thirdTodoId, thirdIdRef);
+            // Assert
+            Assert.Equal(expectedFirstTodoId, actualFirstTodoId);
+            Assert.Equal(expectedSecondTodoId, actualSecondTodoId);
+            Assert.Equal(expectedThirdTodoId, actualThirdTodoId);
         }
 
         [Fact]
-        public void TodoSequencer_TestIdReset()
+        public void TodoIdResetWorks()
         {
             // Arrange
-            int todoIdRef = 1;
-            int todoId;
+            int expectedTodoId = 1;
+            int actualTodoId;
 
             // Act
-            TodoSequencer.NextTodoId();
-            TodoSequencer.NextTodoId();
-            TodoSequencer.Reset();
-            todoId = TodoSequencer.NextTodoId();
+            TodoSequencer.nextTodoId();
+            TodoSequencer.nextTodoId();
+            TodoSequencer.reset();
+            actualTodoId = TodoSequencer.nextTodoId();
 
-            // Assert        
-            Assert.Equal(todoId, todoIdRef);
+            // Assert
+            Assert.Equal(expectedTodoId, actualTodoId);
         }
     }
 }

--- a/ToDoIt/Data/TodoSequencer.cs
+++ b/ToDoIt/Data/TodoSequencer.cs
@@ -19,11 +19,11 @@
         }
 
         // Methods
-        public static int NextTodoId()
+        public static int nextTodoId()
         {
             return ++TodoId;
         }
-        public static int Reset()
+        public static int reset()
         {
             return TodoId = 0;
         }

--- a/ToDoIt/Data/TodoSequencer.cs
+++ b/ToDoIt/Data/TodoSequencer.cs
@@ -4,9 +4,16 @@
     {
         private static int todoId;
 
-        public static int TodoId {
-            get { return todoId; }
-            set { todoId = value; }
+        public static int TodoId
+        {
+            get
+            {
+                return todoId;
+            }
+            set
+            {
+                todoId = value;
+            }
         }
 
         public static int NextTodoId()

--- a/ToDoIt/Data/TodoSequencer.cs
+++ b/ToDoIt/Data/TodoSequencer.cs
@@ -23,7 +23,6 @@
         {
             return ++TodoId;
         }
-
         public static int Reset()
         {
             return TodoId = 0;

--- a/ToDoIt/Data/TodoSequencer.cs
+++ b/ToDoIt/Data/TodoSequencer.cs
@@ -23,9 +23,9 @@
         {
             return ++TodoId;
         }
-        public static int reset()
+        public static void reset()
         {
-            return TodoId = 0;
+            TodoId = 0;
         }
     }
 }

--- a/ToDoIt/Data/TodoSequencer.cs
+++ b/ToDoIt/Data/TodoSequencer.cs
@@ -2,8 +2,10 @@
 {
     public class TodoSequencer
     {
+        // Fields
         private static int todoId;
 
+        // Properties
         public static int TodoId
         {
             get
@@ -16,6 +18,7 @@
             }
         }
 
+        // Methods
         public static int NextTodoId()
         {
             return ++TodoId;


### PR DESCRIPTION
Fix:
- modified `TodoSequencer` class to match it with the assignment requirements. Functions `NextTodoId` and `Reset` were changed to `nextTodoId` and `reset` correspondingly. Also, `reset` function is now void and no longer returns an integer. Other changes include the introduction of subheaders and reformatting of `TodoId` property declaration.
- changed unit test names and variables used to test `TodoSequencer` functionality